### PR TITLE
22 emit bypass

### DIFF
--- a/contracts/Inbox.sol
+++ b/contracts/Inbox.sol
@@ -153,7 +153,7 @@ contract Inbox is IInbox, Ownable {
         }
         if (msg.value > fee) {
             (bool success, ) = payable(msg.sender).call{value: msg.value - fee}("");
-            require(success, "Transfer failed.");
+            require(success, "Native transfer failed.");
         }
         if (_postDispatchHook == address(0)) {
             IMailbox(mailbox).dispatch{value: fee}(
@@ -302,7 +302,7 @@ contract Inbox is IInbox, Ownable {
             revert UnauthorizedTransferNative();
         }
         (bool success, ) = _to.call{value: _amount}("");
-        require(success, "Transfer failed.");
+        require(success, "Native transfer failed.");
     }
 
     /**

--- a/contracts/Inbox.sol
+++ b/contracts/Inbox.sol
@@ -357,6 +357,9 @@ contract Inbox is IInbox, Ownable {
         if (fulfilled[intentHash] != address(0)) {
             revert IntentAlreadyFulfilled(intentHash);
         }
+        if (_claimant == address(0)) {
+            revert ZeroClaimant();
+        }
 
         fulfilled[intentHash] = _claimant;
         emit Fulfillment(_expectedHash, _sourceChainID, _claimant);

--- a/contracts/Inbox.sol
+++ b/contracts/Inbox.sol
@@ -152,7 +152,8 @@ contract Inbox is IInbox, Ownable {
             revert InsufficientFee(fee);
         }
         if (msg.value > fee) {
-            payable(msg.sender).transfer(msg.value - fee);
+            (bool success, ) = payable(msg.sender).call{value: msg.value - fee}("");
+            require(success, "Transfer failed.");
         }
         if (_postDispatchHook == address(0)) {
             IMailbox(mailbox).dispatch{value: fee}(
@@ -243,7 +244,8 @@ contract Inbox is IInbox, Ownable {
             revert InsufficientFee(fee);
         }
         if (msg.value > fee) {
-            payable(msg.sender).transfer(msg.value - fee);
+            (bool success, ) = payable(msg.sender).call{value: msg.value - fee}("");
+            require(success, "Native transfer failed.");
         }
         if (_postDispatchHook == address(0)) { 
             IMailbox(mailbox).dispatch{value: fee}(
@@ -349,18 +351,18 @@ contract Inbox is IInbox, Ownable {
         bytes32 intentHash =
             encodeHash(_sourceChainID, block.chainid, address(this), _targets, _data, _expiryTime, _nonce);
 
-        // revert if locally calculated hash does not match expected hash
         if (intentHash != _expectedHash) {
             revert InvalidHash(_expectedHash);
         }
-
-        // revert if intent has already been fulfilled
         if (fulfilled[intentHash] != address(0)) {
             revert IntentAlreadyFulfilled(intentHash);
         }
+
+        fulfilled[intentHash] = _claimant;
+        emit Fulfillment(_expectedHash, _sourceChainID, _claimant);
+
         // Store the results of the calls
         bytes[] memory results = new bytes[](_data.length);
-        // Call the addresses with the calldata
 
         for (uint256 i = 0; i < _data.length; i++) {
             address target = _targets[i];
@@ -374,12 +376,6 @@ contract Inbox is IInbox, Ownable {
             }
             results[i] = result;
         }
-
-        // Mark the intent as fulfilled
-        fulfilled[intentHash] = _claimant;
-
-        emit Fulfillment(_expectedHash, _sourceChainID, _claimant);
-
         return results;
     }
 

--- a/contracts/IntentSource.sol
+++ b/contracts/IntentSource.sol
@@ -137,14 +137,15 @@ contract IntentSource is IIntentSource {
                 }
             }
             intent.isActive = false;
+            emit Withdrawal(_hash, withdrawTo);
             uint256 len = intent.rewardTokens.length;
             for (uint256 i = 0; i < len; i++) {
                 IERC20(intent.rewardTokens[i]).safeTransfer(withdrawTo, intent.rewardAmounts[i]);
             }
-            emit Withdrawal(_hash, withdrawTo);
             uint256 nativeReward = intent.rewardNative;
             if(nativeReward > 0) {
-                payable(withdrawTo).transfer(nativeReward);
+                (bool success, ) = payable(withdrawTo).call{value: nativeReward}("");
+                require(success, "Native transfer failed.");
             }
         } else {
             revert NothingToWithdraw(_hash);

--- a/contracts/IntentSource.sol
+++ b/contracts/IntentSource.sol
@@ -90,19 +90,18 @@ contract IntentSource is IIntentSource {
             rewardNative: msg.value
         });
 
+        emitIntentCreated(intentHash, intents[intentHash]);
         counter += 1;
 
         for (uint256 i = 0; i < len; i++) {
             IERC20(_rewardTokens[i]).safeTransferFrom(msg.sender, address(this), _rewardAmounts[i]);
         }
 
-        emitIntentCreated(intentHash, intents[intentHash]);
         return intentHash;
     }
 
     function emitIntentCreated(bytes32 _hash, Intent memory _intent) internal {
         //gets around Stack Too Deep
-        //TODO: remove this, stacktoodeep is solved elsewhere
         emit IntentCreated(
             _hash,
             msg.sender,

--- a/contracts/interfaces/IInbox.sol
+++ b/contracts/interfaces/IInbox.sol
@@ -34,11 +34,14 @@ interface IInbox is ISemver{
     // Error thrown when the intent has already been fulfilled
     error IntentAlreadyFulfilled(bytes32 _hash);
 
-    // Error thrown when the intent call failed while itertating through the callAddresses
-    error IntentCallFailed(address _addr, bytes _data, bytes _returnData);
-
     // Error thrown when the hash generated on the inbox contract does not match the expected hash
     error InvalidHash(bytes32 _expectedHash);
+
+    // Error thrown when the claimant in a fulfill call is the zero address
+    error ZeroClaimant();
+
+    // Error thrown when the intent call failed while itertating through the callAddresses
+    error IntentCallFailed(address _addr, bytes _data, bytes _returnData);
 
     // Error thrown when a solver attempts to make a call to the hyperlane mailbox
     error CallToMailbox();

--- a/test/Inbox.spec.ts
+++ b/test/Inbox.spec.ts
@@ -297,6 +297,21 @@ describe('Inbox Test', (): void => {
   })
 
   describe('fulfill when the intent is valid', () => {
+    it('should revert if claimant is zero address', async () => {
+      await expect(
+        inbox
+          .connect(solver)
+          .fulfillStorage(
+            sourceChainID,
+            [erc20Address],
+            [calldata],
+            timeStamp,
+            nonce,
+            ethers.ZeroAddress,
+            intentHash,
+          ),
+      ).to.be.revertedWithCustomError(inbox, 'ZeroClaimant')
+    })
     it('should revert if the call fails', async () => {
       await expect(
         inbox

--- a/test/IntentSource.spec.ts
+++ b/test/IntentSource.spec.ts
@@ -6,7 +6,6 @@ import { time, loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 import { keccak256, BytesLike, ZeroAddress } from 'ethers'
 import { DataHexString } from 'ethers/lib/utils'
 import { encodeIdentifier, encodeTransfer } from '../utils/encode'
-import exp from 'constants'
 
 describe('Intent Source Test', (): void => {
   let intentSource: IntentSource


### PR DESCRIPTION
after 17_zero_claimant

0xweiss said i should use a nonreentrant modifier here, but personally i dont feel this is necessary since reentering this function is not beneficial and doesnt grief anyone. moved the emit above the external call though. 